### PR TITLE
Add simple Jetson video streaming web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # AzrielProject
+
+This repository contains a minimal prototype for streaming video from a Jetson Nano based drone and viewing it over the web. The backend is a small Flask server that provides a single endpoint for a MJPEG stream. The frontend is a lightweight React page. YOLO is used for basic computer vision so the frames can be annotated in real time.
+
+You can run everything on the Jetson or on a regular laptop to experiment. As long as the machine has `opencv-python` and a camera, the code will stream video.
+
+## Structure
+
+- `server/` – Flask backend that captures video, runs YOLO and streams the video frames.
+- `client/` – simple React page served by Flask. It fetches the video stream.
+
+## Requirements
+
+On the Jetson Nano install these Python packages:
+
+```bash
+pip install -r server/requirements.txt
+```
+
+The YOLO model uses the `ultralytics` package which can be heavy. Ensure you have the required dependencies installed on the Jetson (CUDA, etc.).
+
+## Running
+
+1. Start the Flask server on the Jetson or any machine with a camera. The server binds to `0.0.0.0` so it can be reached from other devices on the same network:
+
+```bash
+python3 server/app.py
+```
+
+2. Determine the IP address of the device running the server. On your laptop or phone open `http://<jetson-ip>:5000` to view the stream. Replace `5000` if you set a different port.
+
+3. (Optional) Expose the server publicly using `ngrok` so it can be accessed outside your local network:
+
+```bash
+ngrok http 5000
+```
+
+Use the forwarding URL printed by ngrok in any browser.
+
+## Notes
+
+- The example uses the default camera at `/dev/video0`. Adjust `VideoCapture` if your camera uses another index or pipeline.
+- The YOLO detection overlay is basic but demonstrates how to integrate AI vision.
+
+## Next Steps
+
+- Configure authentication if you expose the stream publicly.
+- Experiment with different YOLO models for improved accuracy or speed.
+- Add flight controls or telemetry endpoints to the Flask server.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Azriel Drone Stream</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+  <style>
+    body {
+      margin: 0;
+      background-color: #121212;
+      color: #eee;
+      font-family: Arial, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      text-align: center;
+    }
+    .controls {
+      margin: 1rem;
+    }
+    button {
+      padding: 0.5rem 1rem;
+      margin: 0 0.25rem;
+      background-color: #333;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button:hover {
+      background-color: #555;
+    }
+    img {
+      width: 90%;
+      max-width: 800px;
+      border-radius: 8px;
+      border: 2px solid #333;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/javascript">
+    function App() {
+      const [running, setRunning] = React.useState(true);
+      const toggle = () => setRunning(!running);
+      return React.createElement('div', null,
+        React.createElement('h1', null, 'Azriel Drone Stream'),
+        React.createElement('div', { className: 'controls' },
+          React.createElement('button', { onClick: toggle }, running ? 'Stop' : 'Start')
+        ),
+        running && React.createElement('img', { src: '/video_feed', alt: 'Video stream' })
+      );
+    }
+    ReactDOM.render(React.createElement(App), document.getElementById('root'));
+  </script>
+</body>
+</html>

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,55 @@
+import io
+import threading
+import time
+
+from flask import Flask, Response, send_from_directory
+import cv2
+
+try:
+    from ultralytics import YOLO
+    yolo_model = YOLO('yolov8n.pt')
+except Exception as e:
+    yolo_model = None
+    print(f"YOLO model could not be loaded: {e}")
+
+app = Flask(__name__, static_folder='../client')
+
+camera_lock = threading.Lock()
+video_capture = cv2.VideoCapture(0)
+
+
+def generate_frames():
+    while True:
+        with camera_lock:
+            success, frame = video_capture.read()
+        if not success:
+            time.sleep(0.1)
+            continue
+
+        if yolo_model:
+            # run inference
+            results = yolo_model(frame)
+            annotated_frame = results[0].plot()
+        else:
+            annotated_frame = frame
+
+        ret, buffer = cv2.imencode('.jpg', annotated_frame)
+        if not ret:
+            continue
+        frame_bytes = buffer.tobytes()
+        yield (b'--frame\r\n'
+               b'Content-Type: image/jpeg\r\n\r\n' + frame_bytes + b'\r\n')
+
+
+@app.route('/video_feed')
+def video_feed():
+    return Response(generate_frames(), mimetype='multipart/x-mixed-replace; boundary=frame')
+
+
+@app.route('/')
+def index():
+    return send_from_directory('../client', 'index.html')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, threaded=True)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+opencv-python
+ultralytics


### PR DESCRIPTION
## Summary
- add Flask server for capturing video and serving via `/video_feed`
- integrate YOLO using ultralytics for basic object detection
- add minimal React page to display the stream
- document installation and usage
- expand README with local network instructions and next steps
- add dark mode styling and start/stop controls to React page

## Testing
- `python3 -m py_compile server/app.py`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687113fb17d0832d8d01d09cb1351906